### PR TITLE
Ensure datapackage<1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pytest==3.0.5
 requests==2.13.0
-datapackage
+datapackage<1.0
 -e git+http://github.com/CT-Data-Collaborative/pytest-ctdata-datapackage.git#egg=pytest-ctdata
 -e git+http://github.com/CT-Data-Collaborative/ctdata-datapackage-publisher.git#egg=ctdata-datapackage-publisher


### PR DESCRIPTION
Hi! Frictionless Data's `datapackage-py` is going to reach v1 release and it could be breaking for some software (we use SemVer). Adding `<1.0` version requirement.